### PR TITLE
[WIP] Parallel download with config

### DIFF
--- a/gen_large_file.go
+++ b/gen_large_file.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/binary"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// Maximum size for a single random read (4MB)
+	maxRandomSize = 4 * 1024 * 1024
+)
+
+type GenerationResult struct {
+	SizeGB     int
+	OutputFile string
+	Duration   time.Duration
+	Error      error
+}
+
+func generateLargeFile(sizeGB int, outputFile string, chunkSizeMB int) error {
+	startTime := time.Now()
+
+	// Convert GB to bytes
+	totalSize := int64(sizeGB) * 1024 * 1024 * 1024
+
+	// Convert chunk size from MB to bytes
+	chunkSize := int64(chunkSizeMB) * 1024 * 1024
+
+	// Calculate number of chunks
+	numChunks := totalSize / chunkSize
+
+	// Create output directory if it doesn't exist
+	outputDir := filepath.Dir(outputFile)
+	if outputDir != "" {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("failed to create output directory: %v", err)
+		}
+	}
+
+	// Create the output file
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %v", err)
+	}
+	defer file.Close()
+
+	// Buffer for random data
+	buffer := make([]byte, maxRandomSize)
+	// Initialize random source with current time
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for chunkNum := int64(0); chunkNum < numChunks; chunkNum++ {
+		// Write chunk number (4 bytes)
+		if err := binary.Write(file, binary.BigEndian, uint32(chunkNum)); err != nil {
+			return fmt.Errorf("failed to write chunk number: %v", err)
+		}
+
+		// Generate random content for the rest of the chunk
+		remainingSize := chunkSize - 4
+		for remainingSize > 0 {
+			currentSize := min(remainingSize, maxRandomSize)
+			// Fill buffer with random bytes
+			for i := 0; i < int(currentSize); i++ {
+				buffer[i] = byte(r.Intn(256))
+			}
+			if _, err := file.Write(buffer[:currentSize]); err != nil {
+				return fmt.Errorf("failed to write random data: %v", err)
+			}
+			remainingSize -= currentSize
+		}
+
+		// Print progress every 100 chunks
+		if chunkNum%100 == 0 {
+			progress := float64(chunkNum) / float64(numChunks) * 100
+			fmt.Printf("Generating file %s %d/%d = %.2f%% done\n", outputFile, chunkNum, numChunks, progress)
+		}
+	}
+
+	endTime := time.Now()
+	totalTime := endTime.Sub(startTime)
+	fmt.Printf("Generated file of size %dGB in %.2f seconds\n", sizeGB, totalTime.Seconds())
+	fmt.Printf("Average write speed: %.2f GB/s\n", float64(sizeGB)/totalTime.Seconds())
+
+	return nil
+}
+
+func generateLargeFiles(sizesGB []int, outputPrefix string, chunkSizeMB int) []GenerationResult {
+	var wg sync.WaitGroup
+	resultChan := make(chan GenerationResult, len(sizesGB))
+
+	for _, sizeGB := range sizesGB {
+		wg.Add(1)
+		go func(sizeGB int, outputFile string) {
+			defer wg.Done()
+			startTime := time.Now()
+			err := generateLargeFile(sizeGB, outputFile, chunkSizeMB)
+			resultChan <- GenerationResult{
+				SizeGB:     sizeGB,
+				OutputFile: outputFile,
+				Duration:   time.Since(startTime),
+				Error:      err,
+			}
+		}(sizeGB, fmt.Sprintf("%s%dgb.bin", outputPrefix, sizeGB))
+	}
+
+	// Wait for all goroutines to complete
+	wg.Wait()
+	close(resultChan)
+
+	// Collect results
+	var allResults []GenerationResult
+	for result := range resultChan {
+		allResults = append(allResults, result)
+	}
+
+	return allResults
+}
+
+func min(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+/*
+# Generate files from 1GB to 5GB in parallel
+go run gen_large_file.go -start-size 1 -end-size 5
+
+# Generate files from 2GB to 10GB with custom prefix and chunk size
+go run gen_large_file.go -start-size 2 -end-size 10 -output-prefix "upload/" -chunk-size 32
+*/
+func main() {
+	var (
+		startSizeGB  int
+		endSizeGB    int
+		outputPrefix string
+		chunkSizeMB  int
+	)
+
+	flag.IntVar(&startSizeGB, "start-size", 1, "Starting size of files in GB")
+	flag.IntVar(&endSizeGB, "end-size", 1, "Ending size of files in GB")
+	flag.StringVar(&outputPrefix, "output-prefix", "large_file_", "Prefix for output files")
+	flag.IntVar(&chunkSizeMB, "chunk-size", 16, "Size of each chunk in MB")
+	flag.Parse()
+
+	if startSizeGB > endSizeGB {
+		fmt.Fprintf(os.Stderr, "Error: start-size must be less than or equal to end-size\n")
+		os.Exit(1)
+	}
+
+	// Create array of sizes
+	var sizesGB []int
+	for size := startSizeGB; size <= endSizeGB; size++ {
+		sizesGB = append(sizesGB, size)
+	}
+
+	// Generate files in parallel
+	results := generateLargeFiles(sizesGB, outputPrefix, chunkSizeMB)
+
+	// Print summary
+	fmt.Println("\nGeneration Summary:")
+	fmt.Println("------------------")
+	for _, result := range results {
+		if result.Error != nil {
+			fmt.Printf("Failed to generate %dGB file: %v\n", result.SizeGB, result.Error)
+		} else {
+			fmt.Printf("Generated %dGB file in %.2f seconds (%.2f GB/s)\n",
+				result.SizeGB,
+				result.Duration.Seconds(),
+				float64(result.SizeGB)/result.Duration.Seconds())
+		}
+	}
+}

--- a/wandb/__init__.py
+++ b/wandb/__init__.py
@@ -85,6 +85,7 @@ from wandb.sdk.internal import profiler
 
 # Artifact import types
 from wandb.sdk.artifacts.artifact_ttl import ArtifactTTL
+from wandb.sdk import ArtifactDownloadConfig
 
 # Used to make sure we don't use some code in the incorrect process context
 _IS_INTERNAL_PROCESS = False
@@ -238,6 +239,7 @@ __all__ = (
     "Molecule",
     "Histogram",
     "ArtifactTTL",
+    "ArtifactDownloadConfig",
     "log_artifact",
     "use_artifact",
     "log_model",

--- a/wandb/sdk/__init__.py
+++ b/wandb/sdk/__init__.py
@@ -5,6 +5,7 @@ __all__ = (
     "Settings",
     "Summary",
     "Artifact",
+    "ArtifactDownloadConfig",
     "AlertLevel",
     "init",
     "setup",
@@ -23,6 +24,7 @@ __all__ = (
 
 from . import wandb_helper as helper
 from .artifacts.artifact import Artifact
+from .artifacts.storage_policy import ArtifactDownloadConfig
 from .wandb_alerts import AlertLevel
 from .wandb_config import Config
 from .wandb_init import _attach, init

--- a/wandb/sdk/artifacts/artifact.py
+++ b/wandb/sdk/artifacts/artifact.py
@@ -53,7 +53,11 @@ from wandb.sdk.artifacts.staging import get_staging_dir
 from wandb.sdk.artifacts.storage_handlers.gcs_handler import _GCSIsADirectoryError
 from wandb.sdk.artifacts.storage_layout import StorageLayout
 from wandb.sdk.artifacts.storage_policies import WANDB_STORAGE_POLICY
-from wandb.sdk.artifacts.storage_policy import StoragePolicy
+from wandb.sdk.artifacts.storage_policy import (
+    DEFAULT_DOWNLOAD_CONFIG,
+    ArtifactDownloadConfig,
+    StoragePolicy,
+)
 from wandb.sdk.data_types._dtypes import Type as WBType
 from wandb.sdk.data_types._dtypes import TypeRegistry
 from wandb.sdk.internal.internal_api import Api as InternalApi
@@ -1749,6 +1753,7 @@ class Artifact:
         allow_missing_references: bool = False,
         skip_cache: bool | None = None,
         path_prefix: StrPath | None = None,
+        download_config: ArtifactDownloadConfig = DEFAULT_DOWNLOAD_CONFIG,
     ) -> FilePathStr:
         """Download the contents of the artifact to the specified root directory.
 
@@ -1793,6 +1798,7 @@ class Artifact:
             allow_missing_references=allow_missing_references,
             skip_cache=skip_cache,
             path_prefix=path_prefix,
+            download_config=download_config,
         )
 
     def _download_using_core(
@@ -1861,6 +1867,7 @@ class Artifact:
         allow_missing_references: bool = False,
         skip_cache: bool | None = None,
         path_prefix: StrPath | None = None,
+        download_config: ArtifactDownloadConfig = DEFAULT_DOWNLOAD_CONFIG,
     ) -> FilePathStr:
         nfiles = len(self.manifest.entries)
         size = sum(e.size or 0 for e in self.manifest.entries.values())
@@ -1887,7 +1894,12 @@ class Artifact:
             _thread_local_api_settings.headers = headers
 
             try:
-                entry.download(root, skip_cache=skip_cache, executor=executor)
+                entry.download(
+                    root,
+                    skip_cache=skip_cache,
+                    executor=executor,
+                    download_config=download_config,
+                )
             except FileNotFoundError as e:
                 if allow_missing_references:
                     wandb.termwarn(str(e))
@@ -1898,7 +1910,10 @@ class Artifact:
                 return
             download_logger.notify_downloaded()
 
-        with concurrent.futures.ThreadPoolExecutor(64) as executor:
+        # https://github.com/wandb/wandb/issues/6579
+        with concurrent.futures.ThreadPoolExecutor(
+            download_config.thread_pool_size
+        ) as executor:
             download_entry = partial(
                 _download_entry,
                 executor=executor,

--- a/wandb/sdk/artifacts/artifact_file_cache.py
+++ b/wandb/sdk/artifacts/artifact_file_cache.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import IO, TYPE_CHECKING, ContextManager, Iterator
+from typing import IO, TYPE_CHECKING, ContextManager, Iterator, Protocol
 
 import wandb
 from wandb import env, util
@@ -19,13 +19,9 @@ from wandb.sdk.lib.filesystem import files_in
 from wandb.sdk.lib.hashutil import B64MD5, ETag, b64_to_hex_id
 from wandb.sdk.lib.paths import FilePathStr, StrPath, URIStr
 
-if TYPE_CHECKING:
-    from typing import Protocol
-
-    class Opener(Protocol):
-        def __call__(self, mode: str = ...) -> ContextManager[IO]:
-            pass
-
+class Opener(Protocol):
+    def __call__(self, mode: str = ...) -> ContextManager[IO]:
+        pass
 
 def _get_sys_umask_threadsafe() -> int:
     # Workaround to get the current system umask, since

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import concurrent.futures
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -129,7 +130,10 @@ class ArtifactManifestEntry:
         return self._parent_artifact
 
     def download(
-        self, root: str | None = None, skip_cache: bool | None = None
+        self,
+        root: str | None = None,
+        skip_cache: bool | None = None,
+        executor: concurrent.futures.ThreadPoolExecutor | None = None,
     ) -> FilePathStr:
         """Download this artifact entry to the specified root path.
 
@@ -169,7 +173,10 @@ class ArtifactManifestEntry:
             )
         else:
             cache_path = self._parent_artifact.manifest.storage_policy.load_file(
-                self._parent_artifact, self, dest_path=override_cache_path
+                self._parent_artifact,
+                self,
+                dest_path=override_cache_path,
+                executor=executor,
             )
 
         if skip_cache:

--- a/wandb/sdk/artifacts/artifact_manifest_entry.py
+++ b/wandb/sdk/artifacts/artifact_manifest_entry.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
+import concurrent.futures
 import json
 import logging
 import os
-import concurrent.futures
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
+from wandb.sdk.artifacts.storage_policy import (
+    DEFAULT_DOWNLOAD_CONFIG,
+    ArtifactDownloadConfig,
+)
 from wandb.sdk.lib import filesystem
 from wandb.sdk.lib.deprecate import Deprecated, deprecate
 from wandb.sdk.lib.hashutil import (
@@ -134,6 +138,7 @@ class ArtifactManifestEntry:
         root: str | None = None,
         skip_cache: bool | None = None,
         executor: concurrent.futures.ThreadPoolExecutor | None = None,
+        download_config: ArtifactDownloadConfig = DEFAULT_DOWNLOAD_CONFIG,
     ) -> FilePathStr:
         """Download this artifact entry to the specified root path.
 
@@ -177,6 +182,7 @@ class ArtifactManifestEntry:
                 self,
                 dest_path=override_cache_path,
                 executor=executor,
+                download_config=download_config,
             )
 
         if skip_cache:

--- a/wandb/sdk/artifacts/storage_policies/parallel_downloader.py
+++ b/wandb/sdk/artifacts/storage_policies/parallel_downloader.py
@@ -1,0 +1,145 @@
+# A hand written version of parallel downloader
+
+import concurrent.futures
+import functools
+import math
+import queue
+from typing import NamedTuple, Union
+
+import requests
+
+from wandb.sdk.artifacts.artifact_file_cache import Opener
+
+PRAALLEL_DOWNLOAD_SIZE = 1 * 1024 * 1024 * 1024  # 1GB
+
+# TODO: Rename to sentienl? We can also shutdown
+_ALL_CHUNK_DOWNLOADED = object()
+
+
+# TODO: NamedTuple vs TypedDict
+class _ChunkContent(NamedTuple):
+    offset: int
+    data: bytes
+
+
+class _ChunkQueue(queue.Queue):
+    """A blocking queue with no timeout that becomes noop when closed."""
+
+    def __init__(self, maxsize=100):
+        super().__init__(maxsize)
+        # TODO: Do we need a thread safe version of the flag? It is a best effort to reduce resource usage when there is error
+        self._closed = False
+
+    def put(self, item: Union[_ChunkContent, object]):
+        if self._closed:
+            return
+        # TODO: Configure a timeout? It just hangs forever...
+        super().put(item, True, None)
+
+    def get(self):
+        if self._closed:
+            return _ALL_CHUNK_DOWNLOADED
+        return super().get(True, None)
+
+    def close(self):
+        self._closed = True
+
+    def is_closed(self):
+        """If the queue is closed due to previous failure, no need to start new requests."""
+        # TODO: Still need to revisit and apply the queue close logic
+        return self._closed
+
+
+class _ChunkRange(NamedTuple):
+    start: int
+    end: int
+
+
+def _download_chunk(
+    q: _ChunkQueue,
+    session: requests.Session,
+    singed_url: str,
+    range: _ChunkRange,
+    response_content_iter_size_bytes: int,
+) -> None:
+    """Download one chunk base on range."""
+    # Skip if the queue is already closed due to exeception
+    if q.is_closed():
+        return
+
+    headers = {"Range": f"bytes={range.start}-{range.end}"}
+    # TODO: catch exception and retry per chunk, I think there is common retry util in SDK
+    response = session.get(url=singed_url, headers=headers, stream=True)
+    response.raise_for_status()
+
+    file_offset = range.start
+    for content in response.iter_content(chunk_size=response_content_iter_size_bytes):
+        q.put(_ChunkContent(offset=file_offset, data=content))
+        file_offset += len(content)
+
+
+def _write_chunks_to_file(q: _ChunkQueue, file_opener: Opener) -> None:
+    """Write all chunks to disk."""
+    with file_opener("wb") as f:
+        while True:
+            item = q.get()
+            if item is _ALL_CHUNK_DOWNLOADED:
+                return
+            elif isinstance(item, _ChunkContent):
+                # TODO: try catch and close the queue if there is io error
+                chunk = item
+                f.seek(chunk.offset)
+                f.write(chunk.data)
+            else:
+                raise ValueError(f"Unknown queue item type: {type(item)}")
+
+
+class ParallelDownloader:
+    """A parallel downloader using HTTP range requests."""
+
+    def __init__(self):
+        pass
+
+    def download_file(
+        self,
+        executor: concurrent.futures.ThreadPoolExecutor,
+        session: requests.Session,
+        signed_url: str,
+        file_size_bytes: int,
+        file_opener: Opener,
+        chunk_size_bytes: int = 64 * 1024 * 1024,
+        response_content_iter_size_bytes: int = 1024 * 1024,
+    ) -> None:
+        q = _ChunkQueue(maxsize=100)
+
+        # Start downloadign chunks
+        num_chunks = int(math.ceil(file_size_bytes / float(chunk_size_bytes)))
+        download_futures = []
+        for i in range(num_chunks):
+            start = i * chunk_size_bytes
+            end = min(start + chunk_size_bytes, file_size_bytes)
+            download_handler = functools.partial(
+                _download_chunk,
+                q,
+                session,
+                signed_url,
+                _ChunkRange(start, end),
+                response_content_iter_size_bytes,
+            )
+            download_futures.append(executor.submit(download_handler))
+
+        # Start writing to file
+        write_file_handler = functools.partial(_write_chunks_to_file, q, file_opener)
+        write_future = executor.submit(write_file_handler)
+
+        # Wait for download to finish
+        done, not_done = concurrent.futures.wait(
+            download_futures, return_when=concurrent.futures.FIRST_EXCEPTION
+        )
+        try:
+            for fut in done:
+                fut.result()
+        finally:
+            q.put(_ALL_CHUNK_DOWNLOADED)
+
+        write_future.result()

--- a/wandb/sdk/artifacts/storage_policies/parallel_downloader.py
+++ b/wandb/sdk/artifacts/storage_policies/parallel_downloader.py
@@ -103,11 +103,12 @@ def _write_chunks_to_file(
                 chunks_written += 1
                 bytes_written += len(chunk.data)
 
-                if chunks_written % 100 == 0:
+                if chunks_written % 1000 == 0:
                     elapsed_time = time.time() - start_time
                     percentage = (bytes_written / file_size_bytes) * 100
+                    mb_written = bytes_written / 1024 / 1024
                     print(
-                        f"Progress: {bytes_written}/{file_size_bytes} bytes ({percentage:.1f}%) - Time elapsed: {elapsed_time:.1f}s"
+                        f"Progress: {mb_written:.1f}/{file_size_bytes / 1024 / 1024:.1f} MB ({percentage:.1f}%) - Time elapsed: {elapsed_time:.1f}s - Speed: {mb_written / elapsed_time:.1f} MB/s"
                     )
             else:
                 raise ValueError(f"Unknown queue item type: {type(item)}")

--- a/wandb/sdk/artifacts/storage_policy.py
+++ b/wandb/sdk/artifacts/storage_policy.py
@@ -8,6 +8,8 @@ from wandb.sdk.internal.internal_api import Api as InternalApi
 from wandb.sdk.lib.paths import FilePathStr, URIStr
 
 if TYPE_CHECKING:
+    from concurrent.futures import ThreadPoolExecutor
+
     from wandb.filesync.step_prepare import StepPrepare
     from wandb.sdk.artifacts.artifact import Artifact
     from wandb.sdk.artifacts.artifact_manifest_entry import ArtifactManifestEntry
@@ -15,6 +17,8 @@ if TYPE_CHECKING:
 
 
 class StoragePolicy:
+    """Implemented by WandbStoragePolicy."""
+
     @classmethod
     def lookup_by_name(cls, name: str) -> type[StoragePolicy]:
         import wandb.sdk.artifacts.storage_policies  # noqa: F401
@@ -40,6 +44,7 @@ class StoragePolicy:
         artifact: Artifact,
         manifest_entry: ArtifactManifestEntry,
         dest_path: str | None = None,
+        executor: ThreadPoolExecutor | None = None,
     ) -> FilePathStr:
         raise NotImplementedError
 


### PR DESCRIPTION
Updated version of https://github.com/pingleiwandb/wandb/pulls

## Done

- No longer using cursor generated code
- Pass the thread pool down to avoid creating new thread pool for each file. All files in the artifact share same thread pool for multi file and multi part download
- Configurable thread pool size

## TODO

- [ ] Error handling
- [ ] Progress report, seems we are not using tqdm and is relying on go core 
https://github.com/wandb/wandb/pull/7825 and https://github.com/search?q=repo%3Awandb%2Fwandb%20tqdm&type=code

## Config

Paste it here so I can view it ...

```python
DEFAULT_THREAD_POOL_SIZE = 64
DEFAULT_PARALLEL_DOWNLOAD_SIZE_BYTES = 1 * 1024 * 1024 * 1024  # 1GB
DEFAULT_CHUNK_SIZE_BYTES = 64 * 1024 * 1024  # 64MB
DEFAULT_HTTP_RESPONSE_CONTENT_ITER_SIZE_BYTES = 1 * 1024 * 1024  # 1MB


class ArtifactDownloadConfig(NamedTuple):
    """Configuration for downloading files in an artifact.
    Attributes:
        thread_pool_size: The size of the thread pool to use for downloading multiple files in artifact or multiple chunks of a single file.
        parallel: Whether to download in parallel. When set to None, decide automatically base on file size. When set to True/False, force parallel/serial regardless of file size.
        file_size_threshold_bytes: The threshold for deciding whether to download in parallel automatically.
        chunk_size_bytes: The size of each chunk to download.
        http_response_content_iter_size_bytes: The size of the response content iterator.
    """

    thread_pool_size: int = DEFAULT_THREAD_POOL_SIZE
    parallel: bool | None = None
    file_size_threshold_bytes: int = DEFAULT_PARALLEL_DOWNLOAD_SIZE_BYTES
    chunk_size_bytes: int = DEFAULT_CHUNK_SIZE_BYTES
    http_response_content_iter_size_bytes: int = (
        DEFAULT_HTTP_RESPONSE_CONTENT_ITER_SIZE_BYTES
    )
```